### PR TITLE
Remove unused variable from board tests

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -8,7 +8,6 @@ class TestBoard(unittest.TestCase):
         self.board = Board()
 
     def test_initial_setup(self):
-        mid = 4 // 2  # not used
         black = self.board.count(BLACK)
         white = self.board.count(WHITE)
         self.assertEqual(black, 2)


### PR DESCRIPTION
## Summary
- remove unused variable `mid` in `tests/test_board.py`

## Testing
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_684108defedc833296e65818ef5ef430